### PR TITLE
Ultra smol fix to the homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -22,7 +22,7 @@
       </header>
       <section>
         <h1>about&nbsp;&nbsp;////////////////////////////////////</h1>
-        <p>ftp://con is an online antifascist hacker conference organized in response to defcon's decision to have dhs secretary mayorkas give a keynote presentation at defcon 25.</p>
+        <p>ftp://con is an online antifascist hacker conference organized in response to defcon's decision to have dhs secretary mayorkas give a keynote presentation at defcon 29.</p>
         <p>we are entirely volunteer organized and very ad hoc, so if you'd like to help out, get in touch! our email is organizers@ftpcon.com.</p>
       </section>
       <section>


### PR DESCRIPTION
DHS Secretary Mayorkas' keynote was in 2021 at DEFCON 29, not DEFCON 25 (I've just updated the conference number to reflect that).